### PR TITLE
fix: use secured url for reverse proxy documentation uri

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -55,7 +55,7 @@ fi
 
 ask_reverse_proxy() {
     while true; do
-        read -p "Are you using a reverse proxy? (http://docs.5stack.gg/install/reverse-proxy) (y/n): " use_reverse_proxy
+        read -p "Are you using a reverse proxy? (https://docs.5stack.gg/install/reverse-proxy) (y/n): " use_reverse_proxy
         if [ "$use_reverse_proxy" = "y" ] || [ "$use_reverse_proxy" = "n" ]; then
             break
         fi


### PR DESCRIPTION
When executing setup, user should access to the secured link for reverse proxy documentation