### PR TITLE
feat: add Tailscale ACL tag prompt and add env var documentation

### DIFF
--- a/overlays/config/api-config.env.example
+++ b/overlays/config/api-config.env.example
@@ -25,3 +25,13 @@ TAILSCALE_NET_NAME=
 # https://login.tailscale.com/admin/settings/oauth
 # give the `devices` scope
 TAILSCALE_CLIENT_ID=
+
+# Sets the ACL tag used to identify this node in Tailscale.
+# This must match a tag declared in your ACL config:
+# https://login.tailscale.com/admin/acls/file
+# Example: tag:fivestack
+TAILSCALE_ACL_TAG=
+
+#S3_PORT=443
+#S3_USE_SSL=true
+#S3_ENDPOINT=s3.us-east-005.backblazeb2.com


### PR DESCRIPTION
This PR adds support for a custom Tailscale ACL tag (**TAILSCALE_ACL_TAG**).

The script now handles default values, ensures proper `tag:` formatting, and the env example includes new VAR doc.

> BTW: added color vars for readability.

This is just a prep step for a future API PR that will use this tag for access control.