### PR TITLE
fix: add missing TLS host replacement for file-manager ingress

### DIFF
--- a/overlays/dev/kustomization.yaml
+++ b/overlays/dev/kustomization.yaml
@@ -61,6 +61,11 @@ replacements:
         fieldPaths:
           - spec.rules.0.host
       - select:
+          kind: Ingress
+          name: file-manager
+        fieldPaths:
+          - spec.tls.0.hosts.0
+      - select:
           kind: Certificate
           name: 5stack-ssl
         fieldPaths:


### PR DESCRIPTION
The ingress-patch.yaml adds a TLS section with placeholder HOST to all ingresses. The kustomize replacement for file-manager was only targeting spec.rules.0.host but not spec.tls.0.hosts.0, leaving the literal string HOST which is invalid and caused the entire uncategorized resource batch (including the web ingress) to fail deployment in Tilt.