### PR TITLE
bug: dont remove vpn auth for now

### DIFF
--- a/game-node-server-setup.sh
+++ b/game-node-server-setup.sh
@@ -142,7 +142,9 @@ cat <<-EOF >/etc/rancher/k3s/config.yaml
 	node-ip: $TAILSCALE_NODE_IP
 EOF
 
-sed -i '/vpn-auth/d' /etc/systemd/system/k3s.service
+# TODO - right now there is a bug where k3s will not join the tailscale network if the vpn-auth line is not present.
+# gamde nodes seem to be ok, yet to be verified.
+# sed -i '/vpn-auth/d' /etc/systemd/system/k3s.service
 
 mkdir -p /etc/systemd/system/k3s.service.d
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to the provisioning script, but it affects how k3s is configured to join Tailscale so misconfiguration could impact node connectivity.
> 
> **Overview**
> Stops removing the `--vpn-auth` line from the generated `k3s.service` in `game-node-server-setup.sh`, leaving it in place due to an observed bug where k3s fails to join the Tailscale network without it.
> 
> Adds TODO comments documenting the issue and defers the previous `sed -i '/vpn-auth/d' ...` cleanup step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b39c74c88ce81dc6397a4db0c39836f29ba662fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->