### PR TITLE
fix: replace hardcoded cert-manager email with configurable variable

### DIFF
--- a/overlays/cert-manager/issuer.yaml
+++ b/overlays/cert-manager/issuer.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: user@example.com
+    email: ${ACME_EMAIL}
     privateKeySecretRef:
       name: 5stack-issuer
     solvers:

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -233,6 +233,11 @@ if [ -z "$WEB_DOMAIN" ] || [ -z "$WS_DOMAIN" ] || [ -z "$API_DOMAIN" ] || [ -z "
         update_env_var "overlays/config/api-config.env" "MAIL_FROM" "$MAIL_FROM"
     fi
 
+    if [ -z "$ACME_EMAIL" ]; then
+        ACME_EMAIL="$MAIL_FROM"
+        update_env_var "overlays/config/api-config.env" "ACME_EMAIL" "$ACME_EMAIL"
+    fi
+
     if [ -z "$S3_CONSOLE_HOST" ]; then
         S3_CONSOLE_HOST="console.$WEB_DOMAIN"
         update_env_var "overlays/config/s3-config.env" "S3_CONSOLE_HOST" "$S3_CONSOLE_HOST"


### PR DESCRIPTION
## Summary
- Replaced `user@example.com` placeholder in cert-manager issuer with `${ACME_EMAIL}` variable
- `setup-env.sh` auto-defaults `ACME_EMAIL` to the `MAIL_FROM` value (e.g., `hello@yourdomain.com`)

## Test plan
- [ ] Run `setup-env.sh` — verify `ACME_EMAIL` is set in config
- [ ] Apply cert-manager overlay — verify issuer has correct email
- [ ] ACME registration succeeds with Let's Encrypt

Closes #414