### PR TITLE
fix: scope RBAC permissions and remove unused /dev/mem mount

### DIFF
--- a/base/api/rbac/cluster-role.yaml
+++ b/base/api/rbac/cluster-role.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   name: server-creator-clusterrole
 rules:
+  # Nodes are cluster-scoped — patch needed for game server node labeling
   - apiGroups:
       - ''
     resources:
@@ -11,47 +12,12 @@ rules:
       - get
       - list
       - patch
-  - apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - delete
+  # PVs are cluster-scoped — read-only for monitoring storage
   - apiGroups:
       - ''
     resources:
       - persistentvolumes
     verbs:
-      - create
       - get
       - list
       - watch
-      - delete
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-      - jobs/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ''
-    resources:
-      - pods
-      - pods/log
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - patch

--- a/base/api/rbac/role.yaml
+++ b/base/api/rbac/role.yaml
@@ -46,9 +46,26 @@ rules:
       - create
       - get
   - apiGroups:
+      - ''
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
       - 'batch'
     resources:
       - jobs
+      - jobs/status
     verbs:
       - create
       - get

--- a/base/api/rbac/role.yaml
+++ b/base/api/rbac/role.yaml
@@ -87,4 +87,5 @@ rules:
       - get
       - list
       - watch
+      - patch
       - delete

--- a/base/game-server-node-connector/daemonset.yaml
+++ b/base/game-server-node-connector/daemonset.yaml
@@ -80,9 +80,6 @@ spec:
             - name: cpu-sys
               mountPath: /host-cpu
               readOnly: true
-            - name: mem-sys
-              mountPath: /host-mem
-              readOnly: true
       volumes:
         - name: server-files
           hostPath:
@@ -114,6 +111,3 @@ spec:
         - name: cpu-sys
           hostPath:
             path: /sys/devices/system/cpu/
-        - name: mem-sys
-          hostPath:
-            path: /dev/mem


### PR DESCRIPTION
## Summary

**API ClusterRole** scoped down to only cluster-scoped resources:
- Kept: `nodes` (get/list/patch for game server node labeling) and `persistentvolumes` (read-only)
- Removed: PVCs, jobs, pods, deployments — moved to namespaced Role where they belong
- PV permissions reduced from create/delete to read-only (PVs are created by storage class via PVCs)

**API Role** (namespaced to 5stack):
- Added `persistentvolumeclaims` (full CRUD, moved from ClusterRole)
- Added `pods/log` (get) and `jobs/status` (moved from ClusterRole)

**DaemonSet**:
- Removed `/dev/mem` volume mount — confirmed not referenced anywhere in the connector source code. This was an unnecessary host memory access.

## Test plan
- [ ] API can still label nodes for game server assignment
- [ ] API can create/manage PVCs for game servers within 5stack namespace
- [ ] API can read pod logs and job statuses
- [ ] Game server node connector starts correctly without /dev/mem mount
- [ ] `kustomize build` succeeds

Closes #412