### PR TITLE
fix: grant server-creator events permission for boot diagnostics

### DIFF
--- a/base/api/rbac/role.yaml
+++ b/base/api/rbac/role.yaml
@@ -54,6 +54,14 @@ rules:
   - apiGroups:
       - ''
     resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
       - persistentvolumeclaims
     verbs:
       - create


### PR DESCRIPTION
## Summary
- Adds `events` (get/list/watch) to the namespaced `server-creator-role`

## Root cause
api PR 5stackgg/api#166 ([commit `cde4e55`](https://github.com/5stackgg/api/commit/cde4e55729930c429dc9a1a713eb75dda61834ba), merged 2026-04-23) introduced `src/k8s/logging/bootDiagnostics.ts` and a new [`LoggingService.getEventsForObject()`](https://github.com/5stackgg/api/blob/main/src/k8s/logging/logging.service.ts#L642) that calls `coreApi.listNamespacedEvent(...)`. The new code path requires the `events` resource permission, but RBAC wasn't updated alongside it — producing 403s in production:

```
events is forbidden: User "system:serviceaccount:5stack:server-creator"
cannot list resource "events" in API group "" in the namespace "5stack"
```

Verified via `git show 5395a63:base/api/rbac/role.yaml` and the #424 diff that `events` was never previously in the role — this is a missing-grant bug from #166, not a regression from RBAC scoping.

## Test plan
- [ ] Apply on cluster, restart api pod, confirm boot diagnostics no longer log `Failed to list Pod events for ...` 403 warnings
- [ ] `kubectl auth can-i list events --as=system:serviceaccount:5stack:server-creator -n 5stack` returns `yes`

Closes #463