### PR TITLE
feature: daemonset rbac for release channel reconcile

### DIFF
--- a/base/api/rbac/role.yaml
+++ b/base/api/rbac/role.yaml
@@ -97,3 +97,13 @@ rules:
       - watch
       - patch
       - delete
+  - apiGroups:
+      - 'apps'
+    resources:
+      - daemonsets
+    resourceNames:
+      - game-server-node-connector
+      - game-server-node-connector-nvidia
+    verbs:
+      - get
+      - patch


### PR DESCRIPTION
Part of the cross-repo beta release channel feature.

## Changes
- Grant `server-creator-role` `get`/`patch` on `apps/daemonsets`, scoped via `resourceNames` to `game-server-node-connector` and `game-server-node-connector-nvidia` only

The api's release-channel reconcile patches workload image tags (`:latest` <-> `:beta`). Deployments were already covered by the existing `deployments` `patch` grant, but the connectors are DaemonSets. Without this grant the reconcile logs a warning and skips them (fails safe), but they could then never follow the selected channel.

The grant is name-scoped (no `list`/`watch`, no other daemonsets) because the connector daemonsets run privileged with hostPath mounts — a blanket daemonset `patch` would be an unnecessary escalation surface. The reconcile only reads and patches these two by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)