### PR TITLE
fix: distinct RAND32 secrets, literal env writes, pinned kustomize (#547, #556)

### DIFF
--- a/utils/replace_rand32_in_env_files.sh
+++ b/utils/replace_rand32_in_env_files.sh
@@ -8,16 +8,26 @@ replace_rand32_in_env_files() {
         return
     fi
     
-    # Replace $(RAND32) with a random base64 encoded string in all non-example env files
+    # Replace each $(RAND32) with its OWN fresh random value. The previous global
+    # (g) sed used one value per file, so paired secrets came out identical
+    # (e.g. APP_KEY == ENC_SECRET, S3_ACCESS_KEY == S3_SECRET) and learning the
+    # semi-public one leaked its partner. Rewrite line by line using bash's
+    # replace-first substitution (not sed) so each occurrence gets a distinct
+    # value and no secret is ever interpreted as a sed pattern.
     for env_file in "$secrets_dir"/*.env; do
         if [[ -f "$env_file" && ! "$env_file" == *.example ]]; then
-            # Generate a random base64 encoded string
-            random_string=$(openssl rand -base64 32 | tr '/' '_' | tr '=' '_')
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-                sed -i '' "s/\$(RAND32)/$random_string/g" "$env_file"
-            else
-                sed -i "s/\$(RAND32)/$random_string/g" "$env_file"
-            fi
+            local tmp_file
+            tmp_file=$(mktemp)
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                while [[ "$line" == *'$(RAND32)'* ]]; do
+                    # base64 alphabet minus '/' and padding '='; the remaining
+                    # chars ([A-Za-z0-9+_]) are all literal in the replacement.
+                    random_string=$(openssl rand -base64 32 | tr '/' '_' | tr '=' '_')
+                    line=${line/'$(RAND32)'/$random_string}
+                done
+                printf '%s\n' "$line" >> "$tmp_file"
+            done < "$env_file"
+            mv "$tmp_file" "$env_file"
         fi
     done
 }

--- a/utils/setup_kustomize.sh
+++ b/utils/setup_kustomize.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
 setup_kustomize() {
-    if ! [ -f "$(dirname "$0")/kustomize" ] || ! [ -x "$(dirname "$0")/kustomize" ]
+    local dir
+    dir="$(dirname "$0")"
+    if ! [ -f "$dir/kustomize" ] || ! [ -x "$dir/kustomize" ]
     then
         echo "kustomize not found. Installing..."
-        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        # Pin the installer to an immutable release tag rather than the moving
+        # `master` branch, and download-then-run instead of piping the network
+        # straight into bash. The installer itself checksum-verifies the
+        # kustomize binary it fetches for the requested version.
+        local version="5.5.0"
+        local script
+        script="$(mktemp)"
+        if curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v${version}/hack/install_kustomize.sh" -o "$script"; then
+            bash "$script" "$version" "$dir"
+        else
+            echo "Failed to download kustomize installer" >&2
+            rm -f "$script"
+            return 1
+        fi
+        rm -f "$script"
     fi
 }

--- a/utils/update_env_var.sh
+++ b/utils/update_env_var.sh
@@ -11,7 +11,12 @@ update_env_var() {
     # remove any existing line for the key, then append the value literally with
     # printf. Env files are order-independent, so re-appending is safe.
     if [ -f "$file" ] && grep -q "^$key=" "$file" 2>/dev/null; then
-        grep -v "^$key=" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+        # `|| true`: when every surviving line is filtered out (a single-key
+        # file), grep exits 1; without this the mv would be skipped, leaving the
+        # stale line in place next to the appended one. The redirect writes the
+        # (possibly empty) tmp regardless, so mv always runs.
+        grep -v "^$key=" "$file" > "$file.tmp" 2>/dev/null || true
+        mv "$file.tmp" "$file"
     fi
     printf '%s=%s\n' "$key" "$value" >> "$file"
 }

--- a/utils/update_env_var.sh
+++ b/utils/update_env_var.sh
@@ -4,16 +4,15 @@ update_env_var() {
     local file=$1
     local key=$2
     local value=$3
-    
-    if grep -q "^$key=" "$file" 2>/dev/null; then
-        # Key exists, update it
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s|^$key=.*|$key=$value|" "$file"
-        else
-            sed -i "s|^$key=.*|$key=$value|" "$file"
-        fi
-    else
-        echo "$key=$value" >> "$file"
+
+    # Never feed the value through sed: a secret containing sed metacharacters
+    # ('|' delimiter, '&', trailing '\') would corrupt or silently drop the
+    # value (a Steam password like 'p@ss|word' broke the substitution). Instead
+    # remove any existing line for the key, then append the value literally with
+    # printf. Env files are order-independent, so re-appending is safe.
+    if [ -f "$file" ] && grep -q "^$key=" "$file" 2>/dev/null; then
+        grep -v "^$key=" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
     fi
+    printf '%s=%s\n' "$key" "$value" >> "$file"
 }
 


### PR DESCRIPTION
Self-contained shell/secret-handling fixes from the 2026-07 audit. Closes #547, #556.

## Changes

**Distinct value per RAND32 secret + literal env writes (#547)**
- `replace_rand32_in_env_files.sh` generated one random value per file and applied it with a global `sed`, so two `$(RAND32)` placeholders in the same file (e.g. `APP_KEY`/`ENC_SECRET`, `S3_ACCESS_KEY`/`S3_SECRET`) got the **same** value. Now rewritten line by line with bash replace-first so each occurrence gets its own value, and no secret is ever interpreted as a sed pattern. Verified: three placeholders in one file produce three distinct values, no leftover placeholders, non-placeholder lines untouched.
- `update_env_var.sh` interpolated the value into `sed`, so a secret with sed metacharacters (`|` delimiter, `&`, trailing `\`) was corrupted or silently dropped (a Steam password `p@ss|word` broke the substitution). Now removes any existing line and appends with `printf`, writing the value verbatim. Verified with a metacharacter-laden value.

**Pin kustomize installer (#556)**
`setup_kustomize.sh` piped `install_kustomize.sh` from the moving `master` branch straight into `bash`. Now pins the installer to an immutable release tag (`kustomize/v5.5.0`), downloads it to a temp file, then runs it with the version and target dir (the installer checksum-verifies the kustomize binary it fetches).

## Testing

- `bash -n` clean on all three scripts.
- Functional tests (in a scratch dir) for the two `#547` behaviors, both pass (see commit).

## Deferred from this PR (documented on the issues)

- **#540 (mediamtx anonymous publish/api)**: the fix (restrict `authInternalUsers`, bind the control API to localhost, drop the api port from the Service) changes live-streaming behavior. Without a dev stack to confirm the legitimate publisher and any in-cluster API caller keep working, shipping it blind risks taking streaming down. Needs a test pass on the streaming topology.
- **#560 (secrets in process args)**: the OAuth client secret (`curl -d`), the access token (`curl -H Authorization`), and the tailscale auth key (`tailscale up --authkey=`) are all passed in argv. A correct fix routes them through temp files / stdin consistently across `tailscale-api.sh` and `game-node-server-setup.sh`, and the `tailscale up --authkey=file:` form can't be verified against the installed tailscale version here. Left out to avoid a half-fix or breaking the node-join path (P3, one-time interactive setup).
